### PR TITLE
Show alternative parenthesis workaround in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,15 @@ Example:
   ...
 }
 
-// Right
+// Correct
+@if let Some(foo) = {bar} {
+  ...
+}
+@match {foo} {
+  ...
+}
+
+// Also works
 @if let Some(foo) = *&(bar) {
   ...
 }


### PR DESCRIPTION
This code also works, but:

- is more flexible (you can create even larger blocks, e.g. `@if {v == true}` and `@if {v} == true` both work, versus `@if *&(v) == true`)
- looks less hack-y
- is easier to write